### PR TITLE
Get django-voting working with Django 1.11

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -341,7 +341,7 @@ Example usage::
 confirm_vote_message
 ~~~~~~~~~~~~~~~~~~~~
 
-Intended for use in vote confirmatio templates, creates an appropriate
+Intended for use in vote confirmation templates, creates an appropriate
 message asking the user to confirm the given vote for the given object
 description.
 

--- a/src/voting/managers.py
+++ b/src/voting/managers.py
@@ -28,6 +28,44 @@ class VoteManager(models.Manager):
             result['score'] = 0
         return result
 
+    def get_positive_score(self, obj):
+        """
+        Get a dictionary containing the total score for ``obj`` and
+        the number of votes it's received.
+        """
+        ctype = ContentType.objects.get_for_model(obj)
+        result = self.filter(
+            object_id=obj._get_pk_val(),
+            content_type=ctype,
+            vote=1
+        ).aggregate(
+            score=Sum('vote'),
+            num_votes=Count('vote')
+        )
+
+        if result['score'] is None:
+            result['score'] = 0
+        return result
+
+    def get_negative_score(self, obj):
+        """
+        Get a dictionary containing the total score for ``obj`` and
+        the number of votes it's received.
+        """
+        ctype = ContentType.objects.get_for_model(obj)
+        result = self.filter(
+            object_id=obj._get_pk_val(),
+            content_type=ctype,
+            vote=-1
+        ).aggregate(
+            score=Sum('vote'),
+            num_votes=Count('vote')
+        )
+
+        if result['score'] is None:
+            result['score'] = 0
+        return result
+
     def get_scores_in_bulk(self, objects):
         """
         Get a dictionary mapping object ids to total score and number

--- a/src/voting/templatetags/voting_tags.py
+++ b/src/voting/templatetags/voting_tags.py
@@ -19,7 +19,7 @@ class ScoreForObjectNode(template.Node):
 
     def render(self, context):
         try:
-            object = template.resolve_variable(self.object, context)
+            object = template.Variable(self.object).resolve(context)
         except template.VariableDoesNotExist:
             return ''
         context[self.context_var] = Vote.objects.get_score(object)
@@ -33,7 +33,7 @@ class ScoresForObjectsNode(template.Node):
 
     def render(self, context):
         try:
-            objects = template.resolve_variable(self.objects, context)
+            objects = template.Variable(self.objects).resolve(context)
         except template.VariableDoesNotExist:
             return ''
         context[self.context_var] = Vote.objects.get_scores_in_bulk(objects)
@@ -48,8 +48,8 @@ class VoteByUserNode(template.Node):
 
     def render(self, context):
         try:
-            user = template.resolve_variable(self.user, context)
-            object = template.resolve_variable(self.object, context)
+            user = template.Variable(self.user).resolve(context)
+            object = template.Variable(self.object).resolve(context)
         except template.VariableDoesNotExist:
             return ''
         context[self.context_var] = Vote.objects.get_for_user(object, user)
@@ -64,8 +64,8 @@ class VotesByUserNode(template.Node):
 
     def render(self, context):
         try:
-            user = template.resolve_variable(self.user, context)
-            objects = template.resolve_variable(self.objects, context)
+            user = template.Variable(self.user).resolve(context)
+            objects = template.Variable(self.object).resolve(context)
         except template.VariableDoesNotExist:
             return ''
         context[self.context_var] = Vote.objects.get_for_user_in_bulk(objects, user)
@@ -80,8 +80,8 @@ class DictEntryForItemNode(template.Node):
 
     def render(self, context):
         try:
-            dictionary = template.resolve_variable(self.dictionary, context)
-            item = template.resolve_variable(self.item, context)
+            dictionary = template.Variable(self.dictionary).resolve(context)
+            item = template.Variable(self.item).resolve(context)
         except template.VariableDoesNotExist:
             return ''
         context[self.context_var] = dictionary.get(item.id, None)

--- a/src/voting/templatetags/voting_tags.py
+++ b/src/voting/templatetags/voting_tags.py
@@ -65,7 +65,7 @@ class VotesByUserNode(template.Node):
     def render(self, context):
         try:
             user = template.Variable(self.user).resolve(context)
-            objects = template.Variable(self.object).resolve(context)
+            objects = template.Variable(self.objects).resolve(context)
         except template.VariableDoesNotExist:
             return ''
         context[self.context_var] = Vote.objects.get_for_user_in_bulk(objects, user)

--- a/src/voting/urls.py
+++ b/src/voting/urls.py
@@ -7,11 +7,6 @@ from .views import vote_on_object_with_lazy_model
 
 
 urlpatterns = [
-    url(r"^vote/(?P<app_label>[\w\.-]+)/(?P<model_name>\w+)/"\
-        "(?P<object_id>\d+)/(?P<direction>up|down|clear)/$",
-        vote_on_object_with_lazy_model, {
-            "allow_xmlhttprequest": True,
-        },
-        name="voting_vote"
-    ),
+    url(r"^vote/(?P<app_label>[\w\.-]+)/(?P<model_name>\w+)/(?P<object_id>\d+)/(?P<direction>up|down|clear)/$",
+        vote_on_object_with_lazy_model, {"allow_xmlhttprequest": True, }, name="voting_vote"),
 ]

--- a/src/voting/views.py
+++ b/src/voting/views.py
@@ -175,4 +175,6 @@ def xmlhttprequest_vote_on_object(request, model, direction,
     return HttpResponse(json.dumps({
         'success': True,
         'score': Vote.objects.get_score(obj),
+        'positive_score': Vote.objects.get_positive_score(obj),
+        'negative_score': Vote.objects.get_negative_score(obj),
     }))


### PR DESCRIPTION
Get django-voting working with Django 1.11 (which has deprecated template.resolve_variable).

NB - could do with a try / except to maintain compatibility with earlier django versions.