### PR TITLE
Change Vote.object_id type to TextField to support other primary key types like UUIDField.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 * Drop Django 3.0 support.
 * Add Django 3.2 support.
 * Add Python 3.10 support.
+* Change ``Vote.object_id`` type to ``TextField`` to support
+  other primary key types like ``UUIDField``.
 
 1.0 (2021-03-10)
 ----------------

--- a/src/voting/managers.py
+++ b/src/voting/managers.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from django.conf import settings
 from django.db import models
 from django.db.models import Sum, Count
@@ -102,6 +104,10 @@ class VoteManager(models.Manager):
             id, score = item["object_id"], item["score"]
             if not score:
                 continue
+            if isinstance(model._meta.pk, models.AutoField):
+                id = int(id)
+            elif isinstance(model._meta.pk, models.UUIDField):
+                id = UUID(id)
             if id in objects:
                 yield objects[id], int(score)
 

--- a/src/voting/migrations/0002_alter_vote_object_id.py
+++ b/src/voting/migrations/0002_alter_vote_object_id.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('voting', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='vote',
+            name='object_id',
+            field=models.TextField(),
+        ),
+    ]

--- a/src/voting/models.py
+++ b/src/voting/models.py
@@ -21,7 +21,7 @@ class Vote(models.Model):
 
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
-    object_id = models.PositiveIntegerField()
+    object_id = models.TextField()
     object = GenericForeignKey("content_type", "object_id")
     vote = models.SmallIntegerField(choices=SCORES)
     time_stamp = models.DateTimeField(editable=False, default=now)

--- a/tests/test_app/models.py
+++ b/tests/test_app/models.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.db import models
 
 
@@ -9,3 +11,11 @@ class Item(models.Model):
 
     class Meta:
         ordering = ["name"]
+
+
+class ItemWithUUID(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4)
+    name = models.CharField(max_length=50)
+
+    def __str__(self):
+        return f"{self.name}({self.id})"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,7 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 
 from voting.models import Vote
-from test_app.models import Item
+from test_app.models import Item, ItemWithUUID
 
 
 class BasicVotingTests(TestCase):
@@ -11,11 +11,18 @@ class BasicVotingTests(TestCase):
     """
     def setUp(self):
         self.item = Item.objects.create(name="test1")
+        self.item_with_uuid = ItemWithUUID.objects.create(name="test1")
         self.users = []
         for username in ["u1", "u2", "u3", "u4"]:
             self.users.append(
                 User.objects.create_user(username, "%s@test.com" % username, "test")
             )
+
+    def test_print_model_with_uuid_primary_key(self):
+        Vote.objects.record_vote(self.item_with_uuid, self.users[0], +1)
+        expected = f"u1: 1 on {self.item_with_uuid.name}({self.item_with_uuid.id})"
+        result = Vote.objects.all()[0]
+        self.assertEqual(str(result), expected)
 
     def test_print_model(self):
         Vote.objects.record_vote(self.item, self.users[0], +1)
@@ -71,8 +78,10 @@ class VoteRetrievalTests(TestCase):
     """
     def setUp(self):
         self.items = []
+        self.items_with_uuid = []
         for name in ["test1", "test2", "test3", "test4"]:
             self.items.append(Item.objects.create(name=name))
+            self.items_with_uuid.append(ItemWithUUID.objects.create(name=name))
         self.users = []
         for username in ["u1", "u2", "u3", "u4"]:
             self.users.append(
@@ -80,13 +89,20 @@ class VoteRetrievalTests(TestCase):
             )
         for user in self.users:
             Vote.objects.record_vote(self.items[0], user, +1)
+            Vote.objects.record_vote(self.items_with_uuid[0], user, +1)
         for user in self.users[:2]:
             Vote.objects.record_vote(self.items[0], user, 0)
+            Vote.objects.record_vote(self.items_with_uuid[0], user, 0)
         for user in self.users[:2]:
             Vote.objects.record_vote(self.items[0], user, -1)
+            Vote.objects.record_vote(self.items_with_uuid[0], user, -1)
         Vote.objects.record_vote(self.items[1], self.users[0], +1)
         Vote.objects.record_vote(self.items[2], self.users[0], -1)
         Vote.objects.record_vote(self.items[3], self.users[0], 0)
+        Vote.objects.record_vote(self.items_with_uuid[1], self.users[0], +1)
+        Vote.objects.record_vote(self.items_with_uuid[2], self.users[0], -1)
+        Vote.objects.record_vote(self.items_with_uuid[3], self.users[0], 0)
+
 
     def test_get_pos_vote(self):
         vote = Vote.objects.get_for_user(self.items[1], self.users[0])
@@ -106,7 +122,7 @@ class VoteRetrievalTests(TestCase):
     def test_in_bulk1(self):
         votes = Vote.objects.get_for_user_in_bulk(self.items, self.users[0])
         self.assertEqual(
-            [(id, vote.vote) for id, vote in votes.items()], [(1, -1), (2, 1), (3, -1)]
+            [(id, vote.vote) for id, vote in votes.items()], [("1", -1), ("2", 1), ("3", -1)]
         )
 
     def test_empty_items(self):
@@ -122,6 +138,19 @@ class VoteRetrievalTests(TestCase):
         expected = [(self.items[1], 4), (self.items[3], 3), (self.items[2], 2)]
         self.assertEqual(result, expected)
 
+    def test_get_top_for_model_with_uuid_primary_key(self):
+        for user in self.users[1:]:
+            Vote.objects.record_vote(self.items_with_uuid[1], user, +1)
+            Vote.objects.record_vote(self.items_with_uuid[2], user, +1)
+            Vote.objects.record_vote(self.items_with_uuid[3], user, +1)
+        result = list(Vote.objects.get_top(ItemWithUUID))
+        expected = [
+            (self.items_with_uuid[1], 4),
+            (self.items_with_uuid[3], 3),
+            (self.items_with_uuid[2], 2),
+        ]
+        self.assertEqual(result, expected)
+
     def test_get_bottom(self):
         for user in self.users[1:]:
             Vote.objects.record_vote(self.items[1], user, +1)
@@ -135,6 +164,23 @@ class VoteRetrievalTests(TestCase):
         expected = [(self.items[2], -4), (self.items[3], -3), (self.items[1], -2)]
         self.assertEqual(result, expected)
 
+    def test_get_bottom_for_model_with_uuid_primary_key(self):
+        for user in self.users[1:]:
+            Vote.objects.record_vote(self.items_with_uuid[1], user, +1)
+            Vote.objects.record_vote(self.items_with_uuid[2], user, +1)
+            Vote.objects.record_vote(self.items_with_uuid[3], user, +1)
+        for user in self.users[1:]:
+            Vote.objects.record_vote(self.items_with_uuid[1], user, -1)
+            Vote.objects.record_vote(self.items_with_uuid[2], user, -1)
+            Vote.objects.record_vote(self.items_with_uuid[3], user, -1)
+        result = list(Vote.objects.get_bottom(ItemWithUUID))
+        expected = [
+            (self.items_with_uuid[2], -4),
+            (self.items_with_uuid[3], -3),
+            (self.items_with_uuid[1], -2),
+        ]
+        self.assertEqual(result, expected)
+
     def test_get_scores_in_bulk(self):
         for user in self.users[1:]:
             Vote.objects.record_vote(self.items[1], user, +1)
@@ -146,10 +192,28 @@ class VoteRetrievalTests(TestCase):
             Vote.objects.record_vote(self.items[3], user, -1)
         result = Vote.objects.get_scores_in_bulk(self.items)
         expected = {
-            1: {"score": 0, "num_votes": 4},
-            2: {"score": -2, "num_votes": 4},
-            3: {"score": -4, "num_votes": 4},
-            4: {"score": -3, "num_votes": 3},
+            "1": {"score": 0, "num_votes": 4},
+            "2": {"score": -2, "num_votes": 4},
+            "3": {"score": -4, "num_votes": 4},
+            "4": {"score": -3, "num_votes": 3},
+        }
+        self.assertEqual(result, expected)
+
+    def test_get_scores_in_bulk_with_uuid_primary_key(self):
+        for user in self.users[1:]:
+            Vote.objects.record_vote(self.items_with_uuid[1], user, +1)
+            Vote.objects.record_vote(self.items_with_uuid[2], user, +1)
+            Vote.objects.record_vote(self.items_with_uuid[3], user, +1)
+        for user in self.users[1:]:
+            Vote.objects.record_vote(self.items_with_uuid[1], user, -1)
+            Vote.objects.record_vote(self.items_with_uuid[2], user, -1)
+            Vote.objects.record_vote(self.items_with_uuid[3], user, -1)
+        result = Vote.objects.get_scores_in_bulk(self.items_with_uuid)
+        expected = {
+            str(self.items_with_uuid[0].id): {"score": 0, "num_votes": 4},
+            str(self.items_with_uuid[1].id): {"score": -2, "num_votes": 4},
+            str(self.items_with_uuid[2].id): {"score": -4, "num_votes": 4},
+            str(self.items_with_uuid[3].id): {"score": -3, "num_votes": 3},
         }
         self.assertEqual(result, expected)
 


### PR DESCRIPTION
Fixes https://github.com/jazzband/django-voting/issues/23